### PR TITLE
Carrier VAT, order display and product fetch optimisation

### DIFF
--- a/controllers/hook/SellermaniaDisplayAdminOrder.php
+++ b/controllers/hook/SellermaniaDisplayAdminOrder.php
@@ -388,6 +388,10 @@ class SellermaniaDisplayAdminOrderController
         $this->context->smarty->assign('sellermania_status_update', $result_status_update);
         $this->context->smarty->assign('sellermania_shipping_status_update', $result_shipping_status_update);
 
+		// Modif YB : variable pour admin par défaut
+        $this->context->smarty->assign('sellermania_display_default_admin', Configuration::get('SM_ENABLE_DEFAULT_ADMIN'));
+		// Fin Modif YB : variable pour admin par défaut
+		
         $this->context->smarty->assign('sellermania_enable_native_refund_system', Configuration::get('SM_ENABLE_NATIVE_REFUND_SYSTEM'));
 
         return $this->module->compliantDisplay('displayAdminOrder.tpl');

--- a/controllers/hook/SellermaniaGetContent.php
+++ b/controllers/hook/SellermaniaGetContent.php
@@ -98,6 +98,7 @@ class SellermaniaGetContentController
                         'PS_OS_SM_ERR_CONF', 'PS_OS_SM_ERR_CANCEL_CUS', 'PS_OS_SM_ERR_CANCEL_SEL',
                         'PS_OS_SM_AWAITING', 'PS_OS_SM_CONFIRMED', 'PS_OS_SM_TO_DISPATCH',
                         'PS_OS_SM_DISPATCHED', 'PS_OS_SM_CANCEL_CUS', 'PS_OS_SM_CANCEL_SEL',
+			"sm_enable_default_admin", // Modif YB : ajout de paramétrage pour interface par défaut des commandes
         );
         foreach ($this->module->sellermania_marketplaces as $marketplace) {
             $params[] = 'SM_MKP_'.str_replace('.', '_', $marketplace);
@@ -188,7 +189,7 @@ class SellermaniaGetContentController
         }
 
 
-        // Retrieve carriers
+        // Retrieve carriers (last parameter "5" means "All carriers")
         $carriers = Carrier::getCarriers($this->context->language->id, true, false, false, null, 5);
 
         // Assign to Smarty
@@ -225,6 +226,7 @@ class SellermaniaGetContentController
         $this->context->smarty->assign('sm_default_product_id', Configuration::get('SM_DEFAULT_PRODUCT_ID'));
         $this->context->smarty->assign('sm_export_all', Configuration::get('SM_EXPORT_ALL'));
         $this->context->smarty->assign('sm_import_orders', Configuration::get('SM_IMPORT_ORDERS'));
+        $this->context->smarty->assign('sm_enable_default_admin', Configuration::get('SM_ENABLE_DEFAULT_ADMIN')); // Modif YB : interface par défaut des commandes
         $this->context->smarty->assign('sm_order_email', Configuration::get('SM_ORDER_EMAIL'));
         $this->context->smarty->assign('sm_order_token', Configuration::get('SM_ORDER_TOKEN'));
         $this->context->smarty->assign('sm_order_endpoint', Configuration::get('SM_ORDER_ENDPOINT'));

--- a/views/templates/hook/displayAdminOrder.tpl
+++ b/views/templates/hook/displayAdminOrder.tpl
@@ -23,7 +23,9 @@
 *}
 
 <div id="sellermania-template">
-
+{* Modif YB : affichage commande standard *}
+{if $sellermania_display_default_admin!="oui" && $sellermania_display_default_admin!="yes"}
+{* Fin Modif YB : affichage commande standard *}
 
     {************************************************}
     {*************** TITLE TEMPLATE *****************}
@@ -88,6 +90,9 @@
         </table>
     </div>
 
+{* Modif YB : affichage commande standard *}
+{/if}
+{* Fin Modif YB : affichage commande standard *}
 
     {********************************************************}
     {*************** ORDER SUMMARY TEMPLATE *****************}
@@ -295,5 +300,11 @@
     {/if}
 
 </script>
+{* Modif YB : affichage commande standard *}
+{if $sellermania_display_default_admin!="oui" && $sellermania_display_default_admin!="yes"}
+{* Fin Modif YB : affichage commande standard *}
 <script type="text/javascript" src="{$sellermania_module_path}views/js/displayAdminOrder-{$ps_version}.js"></script>
+{* Modif YB : affichage commande standard *}
+{/if}
+{* Fin Modif YB : affichage commande standard *}
 <script type="text/javascript" src="{$sellermania_module_path}views/js/displayAdminOrder.js"></script>

--- a/views/templates/hook/displayGetContentImportOrders.bootstrap.tpl
+++ b/views/templates/hook/displayGetContentImportOrders.bootstrap.tpl
@@ -46,6 +46,20 @@
                             <label for="sm_import_orders_no">{l s='No' mod='sellermania'}</label>
                         </div>
                     </div>
+
+
+					{* Modif YB : utiliser l'admin par défaut *}
+                    <div class="clearfix">
+                        <label class="col-lg-4">{l s='Do you want to use default prestashop order admin ?' mod='sellermania'}</label>
+                        <div class="col-lg-8">
+                            <input type="radio" name="sm_enable_default_admin" id="sm_enable_default_admin_yes" value="yes" {if $sm_enable_default_admin eq 'yes'}checked="checked"{/if} />
+                            <label for="sm_enable_default_admin_yes">{l s='Yes' mod='sellermania'}</label>&nbsp;&nbsp;
+                            <input type="radio" name="sm_enable_default_admin" id="sm_enable_default_admin_no" value="no" {if $sm_enable_default_admin eq 'no' || $sm_enable_default_admin eq ''}checked="checked"{/if} />
+                            <label for="sm_enable_default_admin_no">{l s='No' mod='sellermania'}</label>
+                        </div>
+                    </div>
+					{* Fin Modif YB : utiliser l'admin par défaut *}
+
                     <div id="sm_import_orders_credentials" class="clearfix">
 
                         <br>

--- a/views/templates/hook/displayGetContentImportOrders.tpl
+++ b/views/templates/hook/displayGetContentImportOrders.tpl
@@ -37,6 +37,18 @@
                 <input type="radio" name="sm_import_orders" id="sm_import_orders_yes" value="yes" {if $sm_import_orders eq 'yes'}checked="checked"{/if} /> {l s='Yes' mod='sellermania'}
                 <input type="radio" name="sm_import_orders" id="sm_import_orders_no" value="no" {if $sm_import_orders eq 'no' || $sm_import_orders eq ''}checked="checked"{/if} /> {l s='No' mod='sellermania'}
             </div>
+
+
+			{* Modif YB : utiliser l'admin par défaut *}
+            <div class="margin-form" style="padding-left:15px">
+                <p><b>{l s='Do you want to use default prestashop order admin ?' mod='sellermania'} ({$sm_enable_default_admin})</b></p><br>
+                <input type="radio" name="sm_enable_default_admin" id="sm_enable_default_admin_yes" value="yes" {if $sm_enable_default_admin eq 'yes'}checked="checked"{/if} /> {l s='Yes' mod='sellermania'}
+                <input type="radio" name="sm_enable_default_admin" id="sm_enable_default_admin_no" value="no" {if $sm_enable_default_admin eq 'no' || $sm_enable_default_admin eq ''}checked="checked"{/if} /> {l s='No' mod='sellermania'}
+            </div>
+			{* Fin Modif YB : utiliser l'admin par défaut *}
+
+
+
             <div class="margin-form" style="padding-left:15px" id="sm_import_orders_credentials">
 
                 <br>


### PR DESCRIPTION
* Patch to debug two points :
- VAT calculation on carrier is wrong (actually it was not done), now added on two places
- product lookup fixed in case of product not found because of a specific reference (because of a previous module sending different references). References are now accepted with following formats, ex. : 123_5678 or 123-5678 or 123|5678 or 123#5678 etc.
* Implementing simple option to deactivate specific Sellermania order interface.
When activated the option does not prevent sellermani to work as usual, also it keeps sellermania data visible in the product page.
The standard order mode disables the options to confirm each product individually, but it reenables some standard prestashop functions like order slips or status change